### PR TITLE
fix: Determine available disk space only if mount still exists

### DIFF
--- a/ui/lang/pilot/lang_pilot_enu.txt
+++ b/ui/lang/pilot/lang_pilot_enu.txt
@@ -31,6 +31,7 @@ txt_df_memory="Disk space usage"
 txt_df_from="from"
 txt_df_use="occupied"
 txt_df_free="free"
+txt_df_eval_not_pos="Disk space could not be determined."
 
 txt_autopilot_script_search="Search script to be executed"
 txt_autopilot_script_found="The script was found and will be executed"

--- a/ui/lang/pilot/lang_pilot_ger.txt
+++ b/ui/lang/pilot/lang_pilot_ger.txt
@@ -31,6 +31,7 @@ txt_df_memory="Speicherplatznutzung"
 txt_df_from="von"
 txt_df_use="belegt"
 txt_df_free="frei"
+txt_df_eval_not_pos="Der Speicherplatz konnte nicht ermittelt werden."
 
 txt_autopilot_script_search="Suche auszuführendes Script"
 txt_autopilot_script_found="Das Script wurde gefunden und wird ausgeführt"


### PR DESCRIPTION
fix:
Determine available disk space only if mount still exists. It could be the reason that a Hyper Backup Task is configured to eject the USB disk after successful backup.
Therefore, it is not possible after script execution to determine the disk space from AutoPilot. In this case error handling is necessary to avoid providing wrong information to the log file.