### PR TITLE
Avoid AutoPilot to trigger HB task if device is not ready

### DIFF
--- a/ui/execute.sh
+++ b/ui/execute.sh
@@ -125,13 +125,15 @@ else
 	device="/dev/${par}"
 
 	# Searching for mount points
-	counter=0
 	mountpoint=""
-	while ([ -z "${mountpoint}" ] && [ ${counter} -lt 20 ]); do
-		mountpoint=$(mount 2>&1 | grep "$device" | cut -d ' ' -f3)
-		((counter++))
-		sleep 2
+	loopMaxSecs=30									# Set maximum time (duration) for loop in seconds.
+	loopEndTime=$(( $(date +%s) + loopMaxSecs ))	# Calculate end time of loop.
+
+	while [ -z "${mountpoint}" ] && [ $(date +%s) -lt $loopEndTime ]; do # Loop until mountpoint found or reached maximum duration time.
+		mountpoint=$(mount -l | grep "$device" | awk '{print $3}')
 	done
+	# Explicit wait some seconds to ensure Disk is online and available if there is the usage of a Hyper Backup task.
+	sleep 10
 fi
 
 # Mount (connect) external USB devices


### PR DESCRIPTION
fix:
Modified while loop to detect mount point with a maximum time window instead of counts combined with sleep command. As for now setting the maximum loop time to 30 seconds. Additionally added a sleep of 10 seconds to ensure that the target device is available in Hyper Backup when AutoPilot script is triggering a Hyper Backup task.

Fix issue #13 